### PR TITLE
Compiler directive added to prevent test failure from unused function.

### DIFF
--- a/critic/test/art/product-mixing/MixFilterTestImpl_module.cc.in
+++ b/critic/test/art/product-mixing/MixFilterTestImpl_module.cc.in
@@ -377,7 +377,7 @@ namespace {
   }
 
 #ifndef ART_TEST_NO_STARTEVENT
-  void
+  [[maybe_unused]] void
   MixFilterTestDetail::startEvent(art::Event const&)
   {
     startEvent_called_ = true;


### PR DESCRIPTION
- Test failed due to unused function after concept enforcement in `art`
  library.
